### PR TITLE
Switch Message#links to use the decoded body for parsing links

### DIFF
--- a/lib/mailcatcher/api/mailbox/message.rb
+++ b/lib/mailcatcher/api/mailbox/message.rb
@@ -7,7 +7,7 @@ module MailCatcher
       class Message
         attr_reader :id, :raw
         attr_reader :message_id, :date
-        attr_reader :from, :to, :subject, :body
+        attr_reader :from, :to, :subject, :body, :decoded_body
         attr_reader :mime_type, :charset, :content_type
 
         def initialize(msg)
@@ -21,13 +21,14 @@ module MailCatcher
           @to = mail.to
           @subject = mail.subject
           @body = mail.body.raw_source
+          @decoded_body = mail.decode_body
           @mime_type = mail.mime_type
           @charset = mail.charset
           @content_type = mail.content_type
         end
 
         def links
-          @links ||= URI.extract(@body).select { |s| s.start_with? 'http' }
+          @links ||= URI.extract(@decoded_body).select { |s| s.start_with? 'http' }
         end
       end
     end


### PR DESCRIPTION
Safely handle newlines and Quoted-printable characters.